### PR TITLE
Fix 'slice bounds out of range' error

### DIFF
--- a/breakout.go
+++ b/breakout.go
@@ -80,9 +80,11 @@ func (g *Game) Update(screen *ebiten.Image) error {
 
 func (g *Game) ballHits(b *ball) bool {
 	hit := false
-	for i, t := range g.targets {
+	for i := 0; i < len(g.targets); i++ {
+		t := g.targets[i]
 		if b.x+2*b.radius >= t.x && b.x <= t.x+t.w && b.y+2*b.radius >= t.y && b.y <= t.y+t.h {
 			g.targets = append(g.targets[:i], g.targets[i+1:]...)
+			i--
 			hit = true
 		}
 	}


### PR DESCRIPTION
In `ballHits`, when the brick about to be removed is the last one
of the slice we have a problem since we're cutting the branch
we're sitting on.
A range loop does a copy of the slice but a slice if a reference
to an array in memory so the copied slice still points to the same
array in memory.

Illustration:
https://play.golang.org/p/kTKq8DochSA

```
panic: runtime error: slice bounds out of range [40:38]

exit status 2

To see all goroutines, visit https://github.com/maruel/panicparse#gotraceback

1: running [Created by glfw.(*UserInterface).Run @ ui.go:562]
    breakout-go-game breakout.go:85             (*Game).ballHits(#2, 0xc000440280, 0)
    breakout-go-game breakout.go:67             (*Game).Update(#2, #3, 0x4696c0, 0xc000000180)
    ebiten           imagedumper_desktop.go:106 (*imageDumper).update(0xc000195100, #3, 0x5daf20, 0x95c0e0)
    ebiten           run.go:206                 (*imageDumperGame).Update(#1, #3, 0x5db020, 0xc0002f30d4)
    ebiten           run.go:222                 (*imageDumperGameWithDraw).Update(#1, #3, 0x95c0e0, 0)
    ebiten           uicontext.go:266           (*uiContext).update(0x910740, #4, 0, 0)
    ebiten           uicontext.go:239           (*uiContext).Update(0x910740, #4, 0x5de960, 0x910740)
    glfw             ui.go:810                  (*UserInterface).update(0x8fb540, 0x5de960, 0x910740, 0, 0)
    glfw             ui.go:856                  (*UserInterface).loop(0x8fb540, 0x5de960, 0x910740, 0, 0)
    glfw             ui.go:728                  (*UserInterface).run(0x8fb540, 0x5de960, 0x910740, 0, 0)
    glfw             ui.go:565                  (*UserInterface).Run.func1(0xc000192050, 0xc0001a6120, 0x8fb540, 0x5de960, 0x910740)
```

To fix this we replace the range for-loop with a basic for loop,
and just after removing an element of the slice, we decrement i so
that we're now going to stop iterating 1 element before the end.